### PR TITLE
Skip hash regeneration for already processed files

### DIFF
--- a/Classes/EventListener/FileProcessingEventListener.php
+++ b/Classes/EventListener/FileProcessingEventListener.php
@@ -59,6 +59,11 @@ final readonly class FileProcessingEventListener
             return;
         }
 
+        // FIX: Skip if hash already exists (avoid expensive regeneration on every request)
+        if ($this->processedFileMetadataService->getHash($processedFile) !== null) {
+            return;
+        }
+
         // Generate and store hash for processed file
         $hash = $this->generator->generateFromFile($processedFile);
         if ($hash !== null) {


### PR DESCRIPTION
Added a check to skip hash generation if it already exists.
This trades one cheap database query (SELECT by uid with index) for an expensive file read + image processing + hash computation operation.
